### PR TITLE
Catch error where view_name is not defined

### DIFF
--- a/opbeat_pyramid/subscribers.py
+++ b/opbeat_pyramid/subscribers.py
@@ -234,7 +234,7 @@ def get_status_code(request):
 
 
 def get_route_name(request):
-    if request.view_name:
+    if getattr(request, 'view_name', ''):
         return request.view_name
 
     elif request.matched_route and request.matched_route.name:

--- a/opbeat_pyramid/subscribers.py
+++ b/opbeat_pyramid/subscribers.py
@@ -237,7 +237,7 @@ def get_route_name(request):
     if getattr(request, 'view_name', ''):
         return request.view_name
 
-    elif request.matched_route and request.matched_route.name:
+    elif getattr(request, 'matched_route', '') and request.matched_route.name:
         module_name = get_request_module_name(request)
         return module_name + '.' + request.matched_route.name
 


### PR DESCRIPTION
Hey @monokrome!

Seeing this error in our logs, not sure the origin but this should fix the case where it happens:
````
11:46:05 File "/usr/lib/python2.7/site-packages/pyramid/router.py", line 233, in __call__
11:46:05 response = self.invoke_subrequest(request, use_tweens=True)
11:46:05 File "/usr/lib/python2.7/site-packages/pyramid/router.py", line 219, in invoke_subrequest
11:46:05 request._process_finished_callbacks()
11:46:05 File "/usr/lib/python2.7/site-packages/pyramid/request.py", line 147, in _process_finished_callbacks
11:46:05 callback(self)
11:46:05 File "/usr/lib/python2.7/site-packages/opbeat_pyramid/subscribers.py", line 267, in on_request_finished
11:46:05 route_name = get_route_name(request)
11:46:05 File "/usr/lib/python2.7/site-packages/opbeat_pyramid/subscribers.py", line 237, in get_route_name
11:46:05 if request.view_name:
11:46:05 AttributeError: 'Request' object has no attribute 'view_name'
````